### PR TITLE
Improve Runes of Warding script in Molten Core

### DIFF
--- a/src/scriptdev2/scripts/eastern_kingdoms/molten_core/instance_molten_core.cpp
+++ b/src/scriptdev2/scripts/eastern_kingdoms/molten_core/instance_molten_core.cpp
@@ -16,8 +16,8 @@
 
 /* ScriptData
 SDName: Instance_Molten_Core
-SD%Complete: 25
-SDComment: Majordomos and Ragnaros Event missing
+SD%Complete: 100
+SDComment:
 SDCategory: Molten Core
 EndScriptData */
 
@@ -88,6 +88,36 @@ void instance_molten_core::OnObjectCreate(GameObject* pGo)
         case GO_RUNE_ZETH:
         case GO_RUNE_THERI:
         case GO_RUNE_KORO:
+            // Activate the rune if it was previously doused by a player (encounter set to SPECIAL) 
+            m_mGoEntryGuidStore[pGo->GetEntry()] = pGo->GetObjectGuid();
+            for (uint8 i = 0; i < MAX_MOLTEN_RUNES; ++i)
+            {
+                if (m_aMoltenCoreRunes[i].m_uiRuneEntry == pGo->GetEntry() && GetData(m_aMoltenCoreRunes[i].m_uiType) == SPECIAL)
+                {
+                    pGo->UseDoorOrButton();
+                    break;
+                }
+            }
+            break;
+            // Runes' Flames Circles
+        case GO_CIRCLE_MAGMADAR:
+        case GO_CIRCLE_GEHENNAS:
+        case GO_CIRCLE_GARR:
+        case GO_CIRCLE_SHAZZRAH:
+        case GO_CIRCLE_BARON_GEDDON:
+        case GO_CIRCLE_SULFURON:
+        case GO_CIRCLE_GOLEMAGG:
+            // Delete the Flames Circle around the rune if the boss guarding it is killed 
+            m_mGoEntryGuidStore[pGo->GetEntry()] = pGo->GetObjectGuid();
+            for (uint8 i = 0; i < MAX_MOLTEN_RUNES; ++i)
+            {
+                if (m_aMoltenCoreRunes[i].m_uiFlamesCircleEntry == pGo->GetEntry() && (GetData(m_aMoltenCoreRunes[i].m_uiType) == SPECIAL || GetData(m_aMoltenCoreRunes[i].m_uiType) == DONE))
+                {
+                    pGo->Delete();
+                    break;
+                }
+            }
+            break;
 
             // Majordomo event chest
         case GO_CACHE_OF_THE_FIRE_LORD:
@@ -107,25 +137,25 @@ void instance_molten_core::SetData(uint32 uiType, uint32 uiData)
             m_auiEncounter[uiType] = uiData;
             break;
         case TYPE_MAGMADAR:
-            m_auiEncounter[uiType] = uiData;
-            break;
         case TYPE_GEHENNAS:
-            m_auiEncounter[uiType] = uiData;
-            break;
         case TYPE_GARR:
-            m_auiEncounter[uiType] = uiData;
-            break;
         case TYPE_SHAZZRAH:
-            m_auiEncounter[uiType] = uiData;
-            break;
         case TYPE_GEDDON:
-            m_auiEncounter[uiType] = uiData;
-            break;
         case TYPE_GOLEMAGG:
-            m_auiEncounter[uiType] = uiData;
-            break;
         case TYPE_SULFURON:
             m_auiEncounter[uiType] = uiData;
+            if (uiData == DONE)
+            {
+                for (uint8 i = 0; i < MAX_MOLTEN_RUNES; ++i)
+                {
+                    if (m_aMoltenCoreRunes[i].m_uiType == uiType)
+                    {
+                        if (GameObject* pGo = GetSingleGameObjectFromStorage(m_aMoltenCoreRunes[i].m_uiFlamesCircleEntry))
+                            pGo->Delete();
+                        break;
+                    }
+                }
+            }
             break;
         case TYPE_MAJORDOMO:
             m_auiEncounter[uiType] = uiData;

--- a/src/scriptdev2/scripts/eastern_kingdoms/molten_core/molten_core.h
+++ b/src/scriptdev2/scripts/eastern_kingdoms/molten_core/molten_core.h
@@ -47,10 +47,17 @@ enum
     GO_RUNE_KRESS               = 176956,                   // Magmadar
     GO_RUNE_MOHN                = 176957,                   // Gehennas
     GO_RUNE_BLAZ                = 176955,                   // Garr
-    GO_RUNE_MAZJ                = 176953,                   // Shazzah
+    GO_RUNE_MAZJ                = 176953,                   // Shazzrah
     GO_RUNE_ZETH                = 176952,                   // Geddon
     GO_RUNE_THERI               = 176954,                   // Golemagg
     GO_RUNE_KORO                = 176951,                   // Sulfuron
+    GO_CIRCLE_MAGMADAR          = 178192,                   // Flames circle around each rune, removed when each boss is killed
+    GO_CIRCLE_GEHENNAS          = 178193,
+    GO_CIRCLE_GARR              = 178191,
+    GO_CIRCLE_SHAZZRAH          = 178189,
+    GO_CIRCLE_BARON_GEDDON      = 178188,
+    GO_CIRCLE_GOLEMAGG          = 178190,
+    GO_CIRCLE_SULFURON          = 178187,
 
     MAX_MOLTEN_RUNES            = 7,
     MAX_MAJORDOMO_ADDS          = 8,
@@ -60,18 +67,18 @@ enum
 
 struct sRuneEncounters
 {
-    uint32 m_uiRuneEntry, m_uiType;
+    uint32 m_uiRuneEntry, m_uiFlamesCircleEntry, m_uiType;
 };
 
 static const sRuneEncounters m_aMoltenCoreRunes[MAX_MOLTEN_RUNES] =
 {
-    {GO_RUNE_KRESS, TYPE_MAGMADAR},
-    {GO_RUNE_MOHN,  TYPE_GEHENNAS},
-    {GO_RUNE_BLAZ,  TYPE_GARR},
-    {GO_RUNE_MAZJ,  TYPE_SHAZZRAH},
-    {GO_RUNE_ZETH,  TYPE_GEDDON},
-    {GO_RUNE_THERI, TYPE_GOLEMAGG},
-    {GO_RUNE_KORO,  TYPE_SULFURON}
+    {GO_RUNE_KRESS, GO_CIRCLE_MAGMADAR,     TYPE_MAGMADAR},
+    {GO_RUNE_MOHN,  GO_CIRCLE_GEHENNAS,     TYPE_GEHENNAS},
+    {GO_RUNE_BLAZ,  GO_CIRCLE_GARR,         TYPE_GARR},
+    {GO_RUNE_MAZJ,  GO_CIRCLE_SHAZZRAH,     TYPE_SHAZZRAH},
+    {GO_RUNE_ZETH,  GO_CIRCLE_BARON_GEDDON, TYPE_GEDDON},
+    {GO_RUNE_THERI, GO_CIRCLE_GOLEMAGG,     TYPE_GOLEMAGG},
+    {GO_RUNE_KORO,  GO_CIRCLE_SULFURON,     TYPE_SULFURON}
 };
 
 struct sSpawnLocation


### PR DESCRIPTION
- The Flames Circle protecting each rune now despawns when the boss
guarding it is defeated
- Runes of Warding and Flames Circle GOs will remain respectively
activated and despawned on instance reload

Thanks @evil-at-wow for his precious data